### PR TITLE
add build requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
add a build_system to pyproject.toml. Not fully utilized yet as we are not publishing the package to PyPI.