### PR TITLE
add test coverage and markers

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ def tests(session: nox.Session) -> None:
     session.run(
         "pytest",
         "-q",
-        "--cov=src/goat",
+        "--cov=goat",
         "--cov-report=term-missing",
         *session.posargs,
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,14 @@ def tests(session: nox.Session) -> None:
         "--no-default-groups",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
-    session.run("pytest", "-q")
+    session.run(
+        "pytest",
+        "-q",
+        "--cov=src/goat",
+        "--cov-report=term-missing",
+        "--cov-fail-under=60",  # TODO: raise this to 90%
+        *session.posargs,
+    )
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,6 @@ def tests(session: nox.Session) -> None:
         "-q",
         "--cov=src/goat",
         "--cov-report=term-missing",
-        "--cov-fail-under=60",  # TODO: raise this to 90%
         *session.posargs,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,12 +59,6 @@ line-ending = "auto"
 [tool.ty.environment]
 python = ".venv"
 
-[tool.pytest.ini_options]
-markers = [
-    "slow: marks tests as slow (deselect with 'pytest -m \"not slow\"')",
-    "integration: marks tests as integration tests (deselect with 'pytest -m \"not integration\"')",
-]
-
 [tool.coverage.run]
 source = ["src/goat"]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,21 @@ line-ending = "auto"
 
 [tool.ty.environment]
 python = ".venv"
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselect with 'pytest -m \"not slow\"')",
+    "integration: marks tests as integration tests (deselect with 'pytest -m \"not integration\"')",
+]
+
+[tool.coverage.run]
+source = ["src/goat"]
+branch = true
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ line-ending = "auto"
 python = ".venv"
 
 [tool.coverage.run]
-source = ["src/goat"]
+source = ["goat"]
 branch = true
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ source = ["src/goat"]
 branch = true
 
 [tool.coverage.report]
-fail_under = 80
+fail_under = 60 # increase to 80 when ready
 show_missing = true
 exclude_lines = [
     "pragma: no cover",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Pytest configuration and fixtures."""
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add custom command line options for pytest."""
+    parser.addoption(
+        "--run-slow-tests",
+        action="store_true",
+        default=False,
+        help="Run tests marked as slow",
+    )
+    parser.addoption(
+        "--run-integration-tests",
+        action="store_true",
+        default=False,
+        help="Run tests marked as integration",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Configure pytest with custom markers."""
+    config.addinivalue_line("markers", "slow: marks tests as slow")
+    config.addinivalue_line("markers", "integration: marks tests as integration tests")
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Modify test collection based on command line options."""
+    run_slow = config.getoption("--run-slow-tests")
+    run_integration = config.getoption("--run-integration-tests")
+
+    skip_slow = pytest.mark.skip(reason="need --run-slow-tests option to run")
+    skip_integration = pytest.mark.skip(reason="need --run-integration-tests option to run")
+
+    for item in items:
+        if "slow" in item.keywords and not run_slow:
+            item.add_marker(skip_slow)
+        if "integration" in item.keywords and not run_integration:
+            item.add_marker(skip_integration)
+
+
+# Convenience marker decorators
+slow_test = pytest.mark.slow
+integration_test = pytest.mark.integration

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,6 +1,22 @@
+import time
+
 import pytest
+
+from tests.conftest import integration_test, slow_test
 
 
 @pytest.mark.parametrize("x", [1, 2, 3])
 def test_placeholder(x: int) -> None:
     assert x > 0
+
+
+@integration_test
+def test_integration_placeholder() -> None:
+    time.sleep(3)
+    assert True
+
+
+@slow_test
+def test_slow_placeholder() -> None:
+    time.sleep(5)
+    assert True


### PR DESCRIPTION
- Adds coverage with "fail-under=60", noting that we want to increase this to 80 or 90 % in the future.
- Adds two placeholder test markers, "slow" and "integration" so that we can decorate slow and integration tests accordingly.